### PR TITLE
fix: [GW-2399] Bump activesupport to fix security alerts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 ruby File.read(".ruby-version").chomp
 
-gem "activesupport", "~> 7.0.3.1"
+gem "activesupport", "~> 7.0.7.1"
 gem "aws-sdk-ecs", "~> 1.102.0"
 gem "aws-sdk-route53", "~> 1.70.0"
 gem "multipart-post", "~> 2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (7.0.3.1)
+    activesupport (7.0.7.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -22,6 +22,8 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.3.0)
+    bigdecimal (3.2.2)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     diff-lcs (1.6.2)
@@ -43,6 +45,7 @@ GEM
     multipart-post (2.4.1)
     net-http (0.6.0)
       uri
+    ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
@@ -122,10 +125,13 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  activesupport (~> 7.0.3.1)
+  activesupport (~> 7.0.7.1)
   aws-sdk-ecs (~> 1.102.0)
   aws-sdk-route53 (~> 1.70.0)
+  base64
+  bigdecimal
   multipart-post (~> 2.2)
+  ostruct
   pry
   rake (~> 13.0.6)
   require_all (~> 3.0)


### PR DESCRIPTION
### What
increase the version of activesupport 

### Why
to fix security alerts

Link to Jira card (if applicable):
[GW-2399](https://technologyprogramme.atlassian.net/browse/GW-2399)